### PR TITLE
IE浏览器不能正确解析对象属性缩写

### DIFF
--- a/SiteServer.Web/Home/pages/contents.html
+++ b/SiteServer.Web/Home/pages/contents.html
@@ -237,7 +237,7 @@
           <div class="col-3">
             <multiselect v-on:select="onPageSelect" v-model="page" placeholder="Select one" :options="pageOptions"
               :searchable="false" :show-labels="false">
-              <template slot="singleLabel" slot-scope="{ option }">第 {{ option }} 页（共 {{ pages }} 页）</template>
+              <template slot="singleLabel" slot-scope="props">第 {{ props.option }} 页（共 {{ pages }} 页）</template>
               <template slot="option" slot-scope="props"> 第 {{ props.option }} 页 </template>
             </multiselect>
           </div>

--- a/SiteServer.Web/SiteServer/Cms/contents.cshtml
+++ b/SiteServer.Web/SiteServer/Cms/contents.cshtml
@@ -236,7 +236,7 @@
   <div class="col-3">
     <multiselect v-on:select="onPageSelect" v-model="page" placeholder="Select one" :options="pageOptions" :searchable="false"
       :show-labels="false">
-      <template slot="singleLabel" slot-scope="{ option }">第 {{ option }} 页（共 {{ pages }} 页）</template>
+      <template slot="singleLabel" slot-scope="props">第 {{ props.option }} 页（共 {{ pages }} 页）</template>
       <template slot="option" slot-scope="props">
         第 {{ props.option }} 页
       </template>


### PR DESCRIPTION
IE浏览器内容管理页面空白，修复IE无法正确解析slot-scope的错误。
https://github.com/vuejs/vue/issues/6981#issuecomment-452489007