### PR TITLE
bug-fix

### DIFF
--- a/src/SSCMS.Core/SSCMS.Core.csproj
+++ b/src/SSCMS.Core/SSCMS.Core.csproj
@@ -39,8 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SSCMS" Version="7.0.7" />
-    <!--<ProjectReference Include="..\SSCMS\SSCMS.csproj" />-->
+    <ProjectReference Include="..\SSCMS\SSCMS.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/SSCMS.Core/StlParser/StlElement/StlChannel.cs
+++ b/src/SSCMS.Core/StlParser/StlElement/StlChannel.cs
@@ -269,7 +269,7 @@ namespace SSCMS.Core.StlParser.StlElement
             {
                 type = nameof(StlParserUtility.Title);
             }
-            type = StringUtils.ToLower(type);
+            //type = StringUtils.ToLower(type);
 
             var parsedContent = string.Empty;
 

--- a/src/SSCMS.Core/StlParser/StlElement/StlImage.cs
+++ b/src/SSCMS.Core/StlParser/StlElement/StlImage.cs
@@ -225,13 +225,14 @@ namespace SSCMS.Core.StlParser.StlElement
                     }
                     else
                     {
-                        if (no > 1)
+                        if (no <= 1)
                         {
-                            picUrl = channel.Get<string>(type + (no - 1).ToString());
+                            picUrl = channel.Get<string>(type);
                         }
                         else
                         {
-                            picUrl = channel.Get<string>(type);
+                            var extendName = ColumnsManager.GetExtendName(type, no - 1);
+                            picUrl = channel.Get<string>(extendName);
                         }
                     }
                 }

--- a/src/SSCMS.Core/StlParser/StlElement/StlImage.cs
+++ b/src/SSCMS.Core/StlParser/StlElement/StlImage.cs
@@ -37,6 +37,9 @@ namespace SSCMS.Core.StlParser.StlElement
 	    [StlAttribute(Title = "显示字段存储的第几幅图片，默认为 1")]
 	    private const string No = nameof(No);
 
+        [StlAttribute(Title = "是否清除 HTML 标签")]
+        private const string IsClearTags = nameof(IsClearTags);
+
         [StlAttribute(Title = "如果是引用内容，是否获取所引用内容的值")]
         private const string IsOriginal = nameof(IsOriginal);
         
@@ -55,6 +58,7 @@ namespace SSCMS.Core.StlParser.StlElement
             var topLevel = -1;
             var type = nameof(Content.ImageUrl);
 		    var no = 0;
+            var isClearTags = false;
             var isOriginal = false;
             var src = string.Empty;
             var altSrc = string.Empty;
@@ -112,6 +116,10 @@ namespace SSCMS.Core.StlParser.StlElement
                 {
                     no = TranslateUtils.ToInt(value);
                 }
+                else if (StringUtils.EqualsIgnoreCase(name, IsClearTags))
+                {
+                    isClearTags = TranslateUtils.ToBool(value, true);
+                }
                 else if (StringUtils.EqualsIgnoreCase(name, IsOriginal))
                 {
                     isOriginal = TranslateUtils.ToBool(value, true);
@@ -130,10 +138,10 @@ namespace SSCMS.Core.StlParser.StlElement
                 }
             }
 
-            return await ParseImplAsync(parseManager, attributes, isGetPicUrlFromAttribute, channelIndex, channelName, upLevel, topLevel, type, no, isOriginal, src, altSrc);
+            return await ParseImplAsync(parseManager, attributes, isGetPicUrlFromAttribute, channelIndex, channelName, upLevel, topLevel, type, no, isOriginal, isClearTags, src, altSrc);
 		}
 
-        private static async Task<object> ParseImplAsync(IParseManager parseManager, NameValueCollection attributes, bool isGetPicUrlFromAttribute, string channelIndex, string channelName, int upLevel, int topLevel, string type, int no, bool isOriginal, string src, string altSrc)
+        private static async Task<object> ParseImplAsync(IParseManager parseManager, NameValueCollection attributes, bool isGetPicUrlFromAttribute, string channelIndex, string channelName, int upLevel, int topLevel, string type, int no, bool isOriginal, bool isClearTags, string src, string altSrc)
         {
             var databaseManager = parseManager.DatabaseManager;
             var pageInfo = parseManager.PageInfo;
@@ -211,7 +219,21 @@ namespace SSCMS.Core.StlParser.StlElement
 
                     var channel = await databaseManager.ChannelRepository.GetAsync(channelId);
 
-                    picUrl = channel.ImageUrl;
+                    if (type == nameof(Content.ImageUrl))
+                    {
+                        picUrl = channel.ImageUrl;
+                    }
+                    else
+                    {
+                        if (no > 1)
+                        {
+                            picUrl = channel.Get<string>(type + (no - 1).ToString());
+                        }
+                        else
+                        {
+                            picUrl = channel.Get<string>(type);
+                        }
+                    }
                 }
                 else if (contextType == ParseType.Each)
                 {
@@ -237,8 +259,12 @@ namespace SSCMS.Core.StlParser.StlElement
                 }
                 else
                 {
-                    attributes["src"] = await parseManager.PathManager.ParseSiteUrlAsync(pageInfo.Site, picUrl, pageInfo.IsLocal);
-                    parsedContent = $@"<img {TranslateUtils.ToAttributesString(attributes)}>";
+                    parsedContent = await parseManager.PathManager.ParseSiteUrlAsync(pageInfo.Site, picUrl, pageInfo.IsLocal);
+                    if (!isClearTags)
+                    {
+                        attributes["src"] = (string)parsedContent;
+                        parsedContent = $@"<img {TranslateUtils.ToAttributesString(attributes)}>";
+                    }
                 }
             }
 

--- a/src/SSCMS.Web/Controllers/V1/StlController.Get.cs
+++ b/src/SSCMS.Web/Controllers/V1/StlController.Get.cs
@@ -17,6 +17,8 @@ namespace SSCMS.Web.Controllers.V1
                 return Unauthorized();
             }
 
+            request.InitialParameters();
+
             var stlRequest = new StlRequest();
             await stlRequest.LoadAsync(_authManager, _pathManager, _configRepository, _siteRepository, request);
 
@@ -26,6 +28,9 @@ namespace SSCMS.Web.Controllers.V1
             {
                 return NotFound();
             }
+
+            _parseManager.ContextInfo = stlRequest.ContextInfo;
+            _parseManager.PageInfo = stlRequest.PageInfo;
 
             elementName = $"stl:{StringUtils.ToLower(elementName)}";
 

--- a/src/SSCMS.Web/Controllers/V1/StlController.cs
+++ b/src/SSCMS.Web/Controllers/V1/StlController.cs
@@ -41,6 +41,32 @@ namespace SSCMS.Web.Controllers.V1
             public string SiteDir { get; set; }
             public int ChannelId { get; set; }
             public int ContentId { get; set; }
+
+            public void InitialParameters()
+            {
+                SiteId = InitialIntValue(nameof(SiteId));
+                SiteDir = InitialStringValue(nameof(SiteDir));
+                ChannelId = InitialIntValue(nameof(ChannelId));
+                ContentId = InitialIntValue(nameof(ContentId));
+            }
+
+            private string ToCamelName(string name) => name[0..1].ToLower() + name[1..];
+
+            private int InitialIntValue(string key) => System.Convert.ToInt32(InitialStringValue(key));
+
+            private string InitialStringValue(string key)
+            {
+                if (string.IsNullOrEmpty(key)) return null;
+                if (Remove(key, out string value))
+                {
+                    Remove(ToCamelName(key));
+                }
+                else
+                {
+                    Remove(ToCamelName(key), out value);
+                }
+                return value;
+            }
         }
 
         public class GetResult

--- a/src/SSCMS.Web/Controllers/V1/UsersController.Get.cs
+++ b/src/SSCMS.Web/Controllers/V1/UsersController.Get.cs
@@ -12,12 +12,17 @@ namespace SSCMS.Web.Controllers.V1
         [HttpGet, Route(RouteUser)]
         public async Task<ActionResult<User>> Get([FromRoute] int id)
         {
-            if (!await _accessTokenRepository.IsScopeAsync(_authManager.ApiToken, Constants.ScopeUsers))
+            if (!await _accessTokenRepository.IsScopeAsync(_authManager.ApiToken, Constants.ScopeUsers) &&
+                !(_authManager.IsUser && (id == 0 || id == _authManager.UserId)))
             {
                 return Unauthorized();
             }
 
-            if (!await _userRepository.IsExistsAsync(id)) return NotFound();
+            if (_authManager.IsUser && id == 0)
+            {
+                id = _authManager.UserId;
+            }
+            else if (!await _userRepository.IsExistsAsync(id)) return NotFound();
 
             var user = await _userRepository.GetByUserIdAsync(id);
 


### PR DESCRIPTION
### 1.修复含有大写字母的自定义栏目字段在模板中无法使用的问题 #2799 #2828
### 2.修复STL REST API无法使用的问题 #2784 #2810 
### 3.修复Image元素的 type 和 no 属性（no字段名在“规范代码”提交中更改为通过ColumnsManager.GetExtendName方法获取），并引入isClearTags来只获取图片链接。
### 4.使得User REST API可以获取当前用户信息（通过access token），无需api key。