### PR TITLE
使dynamic标签的elementId可以被获取

### DIFF
--- a/src/SSCMS.Core/StlParser/StlElement/StlDynamic.Utils.cs
+++ b/src/SSCMS.Core/StlParser/StlElement/StlDynamic.Utils.cs
@@ -48,6 +48,7 @@ namespace SSCMS.Core.StlParser.StlElement
 <script type=""text/javascript"" language=""javascript"">
 function stlDynamic{elementId}(page)
 {{
+    var elementId = '{elementId}';
     document.getElementById('{elementId}_loading').style.display = '{display}';
     document.getElementById('{elementId}_success').style.display = 'none';
     document.getElementById('{elementId}_failure').style.display = 'none';


### PR DESCRIPTION
dynamic标签的事件可以获取elementId，从而可以计算出动态创建的html元素Id和动态生成的方法。
需要更新[stl:dynamic](https://sscms.com/docs/v7/stl/dynamic/)  的文档。

Signed-off-by: ben <ben302010@live.cn>