### PR TITLE
fix issue: throw "channelid does not exist" when delete channel

### DIFF
--- a/src/SSCMS.Core/Repositories/ContentRepository.Delete.cs
+++ b/src/SSCMS.Core/Repositories/ContentRepository.Delete.cs
@@ -39,7 +39,7 @@ namespace SSCMS.Core.Repositories
 
             await repository.UpdateAsync(
                 GetQuery(site.Id, channel.Id)
-                    .SetRaw("ChannelId = -ChannelId")
+                    .SetRaw("\"ChannelId\" = -\"ChannelId\"")
                     .Set(nameof(Content.LastEditAdminId), adminId)
                     .WhereIn(nameof(Content.Id), contentIdList)
                     .CachingRemove(cacheKeys.ToArray())


### PR DESCRIPTION
PostgreSQL 删除栏目报错：channelid does not exist。
SQL语句拼接中，ChannelId需用双引号包裹。